### PR TITLE
Add manufacturer field

### DIFF
--- a/managers/cleaners.py
+++ b/managers/cleaners.py
@@ -126,6 +126,7 @@ def phonearena(data):
         ("Colors", "Colors"),
         ("Battery life", "Capacity"),
         ("NFC", "Other"),
+        ("Manufacturer","manufacturer"),
     ]
 
     return dict_mapper(data, maps)

--- a/managers/const.py
+++ b/managers/const.py
@@ -13,4 +13,4 @@ DEFAULT_FIELDNAMES = ['Model', 'GPRS', '2G bands', 'Speed', '3G bands', 'EDGE',
         'Colors', 'Battery life', 'Camera', 'Audio quality', 'Performance',
         'Display', 'Phonebook', 'Call records', 'Games', 'SAR EU',
         'SAR US', 'Protection', 'Keyboard', 'NFC', 'Build', 'Alarm',
-        'Clock', 'Languages']
+        'Clock', 'Languages', 'Manufacturer']

--- a/managers/scrapers.py
+++ b/managers/scrapers.py
@@ -146,6 +146,8 @@ def phonearena(url):
                                     row.select('> ul > li')))
 
         data[name] = value
+        data['manufacturer'] = soup.select(
+                                    '.s_breadcrumbs > ul > li > a')[2].text
 
     # [TODO] Create mapping to DEFAULT_FIELDNAMES
     #!---


### PR DESCRIPTION
Include manufacturer in managers/cleaners.py and managers/const.py

Phonearena will scrape manufacturer based on the value of the
breadcrumb in the navigation bar

`soup.select('.s_breadcrumbs > ul > li > a')[2].text`